### PR TITLE
Add a notification message to prevent error

### DIFF
--- a/biowdl_lint.sh
+++ b/biowdl_lint.sh
@@ -45,7 +45,7 @@ git submodule foreach \
     '
     if [ ${name} != "." ]; then
         git status | grep "Your branch is ahead" && \
-        (echo ERROR: Git detected ${name} is ahead of the remote. Please make sure all submodule changes have been pushed first. && exit 1)
+        echo ERROR: Git detected ${name} is ahead of the remote. Please make sure all submodule changes have been pushed first. && exit 1
     fi
     echo ${name} is not ahead
     '

--- a/biowdl_lint.sh
+++ b/biowdl_lint.sh
@@ -46,6 +46,7 @@ git submodule foreach \
     if [ ${name} != "." ]; then
         git status | grep "Your branch is ahead" && \
         (echo ERROR: Git detected ${name} is ahead of the remote. Please make sure all submodule changes have been pushed first. && exit 1)
+    else
+        echo ${name} is not ahead
     fi
-    echo ${name} is not ahead
     '

--- a/biowdl_lint.sh
+++ b/biowdl_lint.sh
@@ -46,7 +46,6 @@ git submodule foreach \
     if [ ${name} != "." ]; then
         git status | grep "Your branch is ahead" && \
         (echo ERROR: Git detected ${name} is ahead of the remote. Please make sure all submodule changes have been pushed first. && exit 1)
-    else
-        echo ${name} is not ahead
     fi
+    echo ${name} is not ahead
     '

--- a/biowdl_lint.sh
+++ b/biowdl_lint.sh
@@ -47,4 +47,5 @@ git submodule foreach \
         git status | grep "Your branch is ahead" && \
         (echo ERROR: Git detected ${name} is ahead of the remote. Please make sure all submodule changes have been pushed first. && exit 1)
     fi
+    echo ${name} is not ahead
     '


### PR DESCRIPTION
Without the notification message, when grep cannot find that a branch is
ahead (i.e. when nothing is wrong), the exit code of the grep command is
1, and this can propagate out of the loop and exit the entire biowdl
script with an error.

Since we call exit 1 explicitly when we encounter a branch that is
ahead, adding this echo statement will make sure that the return code is
0 when no branches have been found to be ahead.